### PR TITLE
Allow for simpler SPARQL queries

### DIFF
--- a/src/main/java/edu/kit/scc/dem/wapsrv/app/FusekiRunner.java
+++ b/src/main/java/edu/kit/scc/dem/wapsrv/app/FusekiRunner.java
@@ -7,6 +7,7 @@ import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration.Dynamic;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.apache.jena.tdb2.TDB2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +74,7 @@ public class FusekiRunner {
             runningServers.clear();
          }
          System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@ Application ready for Fuseki start @@@@@@@@@@@@@@@@@@@@@@");
+         dataBase.getDataBase().getContext().set(TDB2.symUnionDefaultGraph, true);
          // true == read-write
          if (writePort > 0) {
             server1 = FusekiServer.create().port(writePort).add(ENDPOINT_PREFIX, dataBase.getDataBase(), true)


### PR DESCRIPTION
This PR sets the union graph of the TDB2 store as default for fuseki.

This allows for simpler SPARQL queries against the named graphs the individual annotations reside in.

## Before:

**Empty result**

```
SELECT *
WHERE {
  ?s ?p ?o .
}
LIMIT 100
```

**Result with annotation triples**

```
SELECT ?s ?p ?o {
  GRAPH <urn:x-arq:UnionGraph> {
    ?s ?p ?o
  }
} LIMIT 100
```

## Now:

Both queries in general yield the same result.
Change is backward compatible, all named graph queries are working the same way they did before.

There are no expected performance impacts (for better or worse).