### PR TITLE
Allow enabling of typical spring boot endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
     set('javersVersion', "6.8.0")
     set('jenaVersion', "5.4.0")
     set('springBootVersion', "3.4.5")
-    set('springDocVersion', "2.5.0")
+    set('springDocVersion', "2.8.9")
     set('keycloakVersion', "19.0.0")
     set('junitPlatformVersion', "1.11.4")
     set('junitJupiterVersion', "5.11.4")
@@ -82,7 +82,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-data-rest"
     implementation "org.springframework.boot:spring-boot-starter-mail"
-    //implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     //implementation "org.springframework.security:spring-security-web:5.7.5"
     //implementation "org.springframework.security:spring-security-config:5.7.5"
@@ -97,6 +97,8 @@ dependencies {
 
     // springdoc
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-common:${springDocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-api:${springDocVersion}"
 
     //Keycloak
     // implementation "org.keycloak:keycloak-spring-boot-starter:${keycloakVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,8 @@ sourceSets {
                     'doc/**/*.*',
                     'webcontent/**/*.*',
                     'schemas/**/*.*',
-                    'profiles/**/FRAME_*.*'
+                    'profiles/**/FRAME_*.*',
+                    'static/index.html'
             ]
         }
     }
@@ -80,7 +81,8 @@ dependencies {
    // boot starter
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
-    implementation "org.springframework.boot:spring-boot-starter-data-rest"
+    //implementation "org.springframework.boot:spring-boot-starter-data-rest"
+    implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-mail"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 

--- a/src/main/java/edu/kit/scc/dem/wapsrv/app/WapServerConfig.java
+++ b/src/main/java/edu/kit/scc/dem/wapsrv/app/WapServerConfig.java
@@ -14,8 +14,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.PathMatcher;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import edu.kit.scc.dem.wapsrv.controller.WapPathMatcher;
 import java.util.Arrays;
 
@@ -31,7 +31,7 @@ import java.util.Arrays;
  * @version 1.1
  */
 @Configuration
-public class WapServerConfig extends WebMvcConfigurationSupport{
+public class WapServerConfig extends DelegatingWebMvcConfiguration {
 
   /**
    * The endpoint to use for all requests relating to the Web Annotation

--- a/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
+++ b/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
@@ -47,7 +47,7 @@ public class CatchAllController extends BasicController {
     * @throws WapException
     *                      in case any error occurs
     */
-   @RequestMapping(value = "/{[path:[^\\.]*}")
+   @RequestMapping(value = { "/", "/{path:[^\\.]*}" })
    public ResponseEntity<?> catchallRequest(HttpServletRequest request, @RequestHeader HttpHeaders headers)
          throws WapException {
       // The basic idea is that all "real" controllers just intercept those messages

--- a/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
+++ b/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.http.HttpMethod;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,11 @@ import edu.kit.scc.dem.wapsrv.exceptions.InternalServerException;
 import edu.kit.scc.dem.wapsrv.exceptions.InvalidRequestException;
 import edu.kit.scc.dem.wapsrv.exceptions.MethodNotAllowedException;
 import edu.kit.scc.dem.wapsrv.exceptions.WapException;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.springframework.web.servlet.function.RequestPredicates.path;
+import static org.springframework.web.servlet.function.RouterFunctions.route;
 
 /**
  * This controller adds the catch all feature to the server which answers all request that not mapped correctly
@@ -30,15 +37,20 @@ import edu.kit.scc.dem.wapsrv.exceptions.WapException;
  * @version 1.1
  */
 @RestController
-@RequestMapping("/")
 public class CatchAllController extends BasicController {
    @Autowired
    private WapServerConfig wapServerConfig;
 
+   @Bean
+   RouterFunction<ServerResponse> spaRouter() {
+      ClassPathResource index = new ClassPathResource("static/index.html");
+      return route().resource(path("/"), index).build();
+   }
+
    /**
     * This method implements the endpoint that catches all otherwise not mapped requests to create meaningful error
     * messages
-    * 
+    *
     * @param  request
     *                      The request the client sent
     * @param  headers
@@ -47,9 +59,10 @@ public class CatchAllController extends BasicController {
     * @throws WapException
     *                      in case any error occurs
     */
-   @RequestMapping(value = { "/", "/{path:[^\\.]*}" })
+
    public ResponseEntity<?> catchallRequest(HttpServletRequest request, @RequestHeader HttpHeaders headers)
          throws WapException {
+      //TODO: should be obsolete, currently here for sake of existing tests
       // The basic idea is that all "real" controllers just intercept those messages
       // that truly fit them and check their parameters, headers and so on there.
       // All request that do not exactly fit one request and cannot be mapped, land here

--- a/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
+++ b/src/main/java/edu/kit/scc/dem/wapsrv/controller/CatchAllController.java
@@ -47,7 +47,7 @@ public class CatchAllController extends BasicController {
     * @throws WapException
     *                      in case any error occurs
     */
-   @RequestMapping(value = "**")
+   @RequestMapping(value = "/{[path:[^\\.]*}")
    public ResponseEntity<?> catchallRequest(HttpServletRequest request, @RequestHeader HttpHeaders headers)
          throws WapException {
       // The basic idea is that all "real" controllers just intercept those messages

--- a/src/test/java/edu/kit/scc/dem/wapsrv/testsrest/AnnotationRestTest.java
+++ b/src/test/java/edu/kit/scc/dem/wapsrv/testsrest/AnnotationRestTest.java
@@ -795,7 +795,7 @@ public class AnnotationRestTest extends AbstractRestTest {
         // The annotation does not have to exist for this test
         String containerIri = createDefaultContainer(null); // in the root container
         try {
-            URL url = new URL(containerIri);
+            URL url = new URL(containerIri + "anno1");
             String params = "test=1";
             Map<String, Object> requestHeaders = new Hashtable<String, Object>();
             requestHeaders.put("Content-Type", "application/ld+json;profile=\"http://www.w3.org/ns/anno.jsonld\"");
@@ -805,7 +805,7 @@ public class AnnotationRestTest extends AbstractRestTest {
                     = performOwnHttpRequest(url, OwnHttpURLConnection.Request.PUT, requestHeaders, params, annotation);
             // logger.trace(response.getTransmittedString());
             // logger.trace(response.getReceivedString());
-            checkException(IllegalHttpParameterException.class, response, ErrorMessageRegistry.ALL_NO_PARAMETERS_IN_PUT);
+            checkException(IllegalHttpParameterException.class, response, "No parameters allowed");
         } catch (MalformedURLException e) {
             fail(e.getMessage());
         }

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,6 @@
+<html>
+A GET request to the server's base url has been received. To interact with this server, there are a few endpoint you can send requests to :<br>
+<ul><li><a href="./wap/">./wap/</a> for requests to the main functinality, the Web Annotation Protocol Service</li>
+    <li><a href="./webapp">./webapp</a> for requests to the Web Annotation Protocol Service Client</li>
+    <li><a href="./javadoc">./javadoc</a> for requests to the the integrated javadoc</li>
+</ul></html>


### PR DESCRIPTION
Add dependencies for
- actuators (health, info, ...)
- swagger-ui / openapi doc

Deprecates catchallcontroller's core functionality. Likely still needs some rework (removal of catchallcontroller tests?).